### PR TITLE
Include LICENSE in package.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     ],
     url='https://github.com/ribozz/sphinx-argparse',
     license='MIT',
+    data_files=[("", ["LICENSE"])],
     author='Aleksandr Rudakov and Devon Ryan',
     author_email='ribozz@gmail.com',
     description='A sphinx extension that automatically documents argparse commands and options',


### PR DESCRIPTION
Use the keyword argument data_files in the setup function in setup.py to
include the LICENSE file in the resulting package.

This is very helpful for including the LICENSE file in a conda package.