### PR TITLE
Travis-ci:added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
+arch:
+  - amd64
+  - ppc64le
 language: python
 python:
   - "2.7"
   - "3.5"
   - "3.6"
+  - "3.7"
 install:
  - pip install .
  - pip install flake8


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch on behalf of IBM. The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/sphinx-argparse/builds/209601979 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!